### PR TITLE
Fix error when editing E-Mail Templates in Joomla 5 ("The Buttons var…

### DIFF
--- a/administrator/components/com_j2store/controllers/emailtemplates.php
+++ b/administrator/components/com_j2store/controllers/emailtemplates.php
@@ -188,7 +188,7 @@ class J2StoreControllerEmailtemplates extends F0FController {
                         'editor' => 'codemirror',
                         'content' => 'from_file',
                         'syntax' => 'php',
-                        'buttons' => 'no',
+                        'buttons' => false,
                         'height' => '500px',
                         'rows' => '20',
                         'cols' => '80',


### PR DESCRIPTION
Fix error when editing E-Mail Templates in Joomla 5 ("The Buttons variable should be an array of names of disabled buttons or boolean."). 

The "buttons" parameter has to be set to false instead of "no"